### PR TITLE
Rework routing on front-end

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,15 +4,16 @@ import { CssBaseline } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 import { theme } from './themes/theme';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
-import Login from './pages/Login/Login';
-import Signup from './pages/SignUp/SignUp';
-import Dashboard from './pages/Dashboard/Dashboard';
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
 import { Navbar } from './components/Navbar/Navbar';
-import Settings from './pages/Settings/Settings';
 import NotFound from './pages/NotFound/NotFound';
+import { appRouteType, appRoutes } from './routes/app';
+
+function renderRoute(route: appRouteType, index: number): JSX.Element {
+  return <Route key={index} path={route.to} component={route.component} exact={route.exact} />;
+}
 
 function App(): JSX.Element {
   return (
@@ -24,10 +25,7 @@ function App(): JSX.Element {
               <CssBaseline />
               <Navbar />
               <Switch>
-                <Route exact path="/login" component={Login} />
-                <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard" component={Dashboard} />
-                <Route path="/profile/settings" component={Settings} />
+                {appRoutes.map((route, index) => renderRoute(route, index))}
                 <Route path="*">
                   <NotFound />
                 </Route>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,9 +9,9 @@ import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
 import { Navbar } from './components/Navbar/Navbar';
 import NotFound from './pages/NotFound/NotFound';
-import { appRouteType, appRoutes } from './routes/app';
+import { AppRouteType, appRoutes } from './routes/app';
 
-function renderRoute(route: appRouteType, index: number): JSX.Element {
+function renderRoute(route: AppRouteType, index: number): JSX.Element {
   return <Route key={index} path={route.to} component={route.component} exact={route.exact} />;
 }
 

--- a/client/src/routes/app.ts
+++ b/client/src/routes/app.ts
@@ -4,14 +4,14 @@ import Dashboard from '../pages/Dashboard/Dashboard';
 import Settings from '../pages/Settings/Settings';
 import { AccountType } from '../types/AccountType';
 
-export interface appRouteType {
+export interface AppRouteType {
   to: string;
   component: React.ComponentType;
   canView: Array<string>;
   exact: boolean;
 }
 
-export const appRoutes = [
+export const appRoutes: AppRouteType[] = [
   {
     to: '/login',
     component: Login,

--- a/client/src/routes/app.ts
+++ b/client/src/routes/app.ts
@@ -28,14 +28,12 @@ export const appRoutes = [
     to: '/dashboard',
     component: Dashboard,
     canView: [AccountType.PET_OWNER, AccountType.PET_SITTER],
-    authenticated: true,
     exact: true,
   },
   {
     to: '/profile/settings',
     component: Settings,
     canView: [AccountType.PET_OWNER, AccountType.PET_SITTER],
-    authenticaed: true,
     exact: false,
   },
 ];

--- a/client/src/routes/app.ts
+++ b/client/src/routes/app.ts
@@ -1,0 +1,41 @@
+import Login from '../pages/Login/Login';
+import Signup from '../pages/SignUp/SignUp';
+import Dashboard from '../pages/Dashboard/Dashboard';
+import Settings from '../pages/Settings/Settings';
+import { AccountType } from '../types/AccountType';
+
+export interface appRouteType {
+  to: string;
+  component: React.ComponentType;
+  canView: Array<string>;
+  exact: boolean;
+}
+
+export const appRoutes = [
+  {
+    to: '/login',
+    component: Login,
+    canView: [AccountType.PET_OWNER, AccountType.PET_SITTER],
+    exact: true,
+  },
+  {
+    to: '/signup',
+    component: Signup,
+    canView: [AccountType.PET_OWNER, AccountType.PET_SITTER],
+    exact: true,
+  },
+  {
+    to: '/dashboard',
+    component: Dashboard,
+    canView: [AccountType.PET_OWNER, AccountType.PET_SITTER],
+    authenticated: true,
+    exact: true,
+  },
+  {
+    to: '/profile/settings',
+    component: Settings,
+    canView: [AccountType.PET_OWNER, AccountType.PET_SITTER],
+    authenticaed: true,
+    exact: false,
+  },
+];


### PR DESCRIPTION
### What this PR does:
- routes/app.ts now stores all routing for the application (e.g. path, component, exact(true/false), etc.)
- added a function in App.tsx to render the routes in routes/app

### Any issues with the current functionality:
- Need to add logic to the function in App.tsx, so that we only render routes applicable to the account type (i.e. depending if the account is a pet sitter or pet owner). **For now, the function renders all routes - to be updated once profile types are updated on the back-end**.
