### PR TITLE
navbar links to bookings pages

### DIFF
--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -42,13 +42,13 @@ const menuItems = [
   },
   {
     item: 'My Jobs',
-    resource: '/my-jobs',
+    resource: '/bookings',
     canView: [AccountType.PET_SITTER],
     authenticated: true,
   },
   {
     item: 'My Sitters',
-    resource: '/sitters',
+    resource: '/mysitters',
     canView: [AccountType.PET_OWNER],
     authenticated: true,
   },


### PR DESCRIPTION
Relates to #79 

### What this PR does (required):
- updated Navbar links for petsitter and customer bookings.
- customer bookings is `/mysitters`, which has yet to be merged in to main branch.
