### PR TITLE
minor changes

### DIFF
--- a/client/src/pages/Settings/Availability/FormInterface.tsx
+++ b/client/src/pages/Settings/Availability/FormInterface.tsx
@@ -45,8 +45,8 @@ const GenerateFormInterface = (day: string, values: any, setFieldValue: any, han
             checked={values[day].active}
             onChange={(e: any) => {
               if (!e.target.checked) {
-                setFieldValue(`${day}.startTime`, '0');
-                setFieldValue(`${day}.endTime`, '0');
+                setFieldValue(`${day}.startTime`, '');
+                setFieldValue(`${day}.endTime`, '');
               } else {
                 setFieldValue(`${day}.startTime`, '10');
                 setFieldValue(`${day}.endTime`, '22');

--- a/client/src/routes/app.ts
+++ b/client/src/routes/app.ts
@@ -47,7 +47,6 @@ export const appRoutes: AppRouteType[] = [
     exact: false,
   },
   {
-
     to: '/mysitters',
     component: CustomerBookings,
     canView: [AccountType.PET_OWNER],


### PR DESCRIPTION
### What this PR does (required):
- Removed extra line break in `app.ts`, slight update to `edit availability` page so that inactive days are now blank (previously was showing '0' startTime but empty endTime, which was inconsistent)

![Screen Shot 2022-02-04 at 8 57 21 AM](https://user-images.githubusercontent.com/96796802/152541062-4cdbc607-3da5-46f4-8707-00b36556f518.png)

